### PR TITLE
Update base image to OpenJDK 26-ea-17-jdk-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official OpenJDK 17 image as the base image
-FROM openjdk:17-jdk-alpine
+FROM openjdk:26-ea-17-jdk-slim
 
 # Set metadata
 LABEL maintainer="trainwithshubham@gmail.com"


### PR DESCRIPTION
Old openjdk:17-jdk-alpine Was expired so I have added new one: openjdk:26-ea-17-jdk-slim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container runtime dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->